### PR TITLE
Checkout to make sure there is a git repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
     docker:
       - image: cimg/node:16.20
     steps:
+      - checkout
       - attach_workspace:
           at: build
       - run:


### PR DESCRIPTION
This is necessary to prevent deployment issues like [this]:

    Failed to get remote.origin.url (task must either be run in a git repository with a configured origin remote or must be configured with the "repo" option).

[this]: https://app.circleci.com/pipelines/github/jfrimmel/cirq/6/workflows/7ba8b1c6-d439-48c2-bd27-ab1f0a543cfc/jobs/7