### PR TITLE
Target newer browsers

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -3,7 +3,7 @@ site = $builddir/site
 
 rule tsc
     description = Compile $in to JavaScript
-    command = tsc --strict --pretty --outFile $out $in
+    command = tsc --strict --pretty --target es6 --outFile $out $in
 
 rule cp
     description = Copy $in to build directory


### PR DESCRIPTION
This commit selects the `es6` target for TypeScript compilation. This yields smaller async/await code, but reduces the amount of supported browsers (only newer browsers support that).