### PR TITLE
Also commit the CI definition on `gh-pages` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ jobs:
           name: Disable jekyll builds
           command: touch build/site/.nojekyll
       - run:
+          # https://discuss.circleci.com/t/cant-ignore-the-gh-pages-branch/2002/4
+          name: Add CircleCI definitions for this branch
+          command: mkdir build/site/.circleci && cp .circleci/config.yml build/site/.circleci/config.yml
+      - run:
           name: Install and configure gh-pages
           command: |
             npm install -g --silent gh-pages@2.0.1


### PR DESCRIPTION
This is a workaround for [issues like this][failed-ci]:

    ❕ Failed to fetch config.yml file.

This workaround is described [here][workaround].

[failed-ci]: https://app.circleci.com/pipelines/github/jfrimmel/cirq/17
[workaround]: https://discuss.circleci.com/t/cant-ignore-the-gh-pages-branch/2002/4