### PR TITLE
Add reproducible builds for PNGs

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -12,7 +12,7 @@ rule cp
 
 rule svg2png
     description = Rendering $in to ${size}px
-    command = convert -background none -resize ${size}x${size} $in $out
+    command = convert -background none -resize ${size}x${size} -define png:exclude-chunks=date,time $in $out
 
 rule svg2ico
     description = Render $in to .ico


### PR DESCRIPTION
This commit addresses an issue in the `gh-pages`-branch: on different deploys, the same `icon.svg` is rendered to the various PNGs. Somewhat unexpectedly, the same input yields different outputs, so that the re- pository (the `gh-pages` branch) contains multiple times the same PNGs, just with different timestamps.
Therefore this commit excludes those timestamps from the generated PNGs.