### PR TITLE
Enable LTO for WASM binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 
 [profile.release]
 opt-level = "s"
+lto = true
 
 [dependencies]
 wasm-bindgen = "0.2"


### PR DESCRIPTION
This can dramatically reduce the size of the binary:

* without LTO

      $ wc -c build/site/scripts/wasm_bg.wasm
      25793 build/site/scripts/wasm_bg.wasm

* with LTO

      $ wc -c build/site/scripts/wasm_bg.wasm
      15011 build/site/scripts/wasm_bg.wasm