### PR TITLE
Add information message if scripts are disabled

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -34,6 +34,7 @@ build $site/icons/64px.png: svg2png icon.svg
 build $site/favicon.ico: svg2ico icon.svg
 build $site/worker.js: tsc src/worker.ts
     jsoutdir = $site
+build $site/images/warning.svg: cp src/images/warning.svg
 
 rule cargo
     description = Compile Rust to WASM

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -3,10 +3,29 @@ html {
     margin: 0;
     padding: 0;
     width: 100%;
+    font-family: Arial, Helvetica, sans-serif;
 }
 
-.title {
-    font-size: 3rem;
+.noscript-msg {
+    display: flex;
+    flex-flow: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    height: 100vh;
+    width: 100%;
+    padding: 3em;
+    box-sizing: border-box;
+    background-color: rgb(253, 253, 99);
+    color: black;
+}
+
+.noscript-maintext {
+    font-size: 1.5rem;
+}
+
+.noscript-subtext {
+    font-size: 1rem;
 }
 
 body {

--- a/src/images/warning.svg
+++ b/src/images/warning.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full"
+    width="32mm" height="32mm" viewBox="-256 -256 512 512">
+    <title>warning icon</title>
+    <desc>Icon of a yellow triangle with an exclamation mark on it.</desc>
+
+    <polygon points="-200,180 200,180 0,-180" fill="yellow" stroke="black" stroke-width="20px" rx="20px" ry="20px"
+        stroke-linejoin="round" />
+    <line x1="0" x2="0" y1="-60" y2="65" stroke="black" stroke-width="30px" stroke-linecap="round" />
+    <circle cx="0" cy="120" r="15px" />
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,19 @@
 </head>
 
 <body>
+    <noscript>
+        <div class="noscript-msg">
+            <img id="noscript-img" src="images/warning.svg" alt="warning icon" />
+            <p class="noscript-maintext">
+                This site is interactive and thus requires JavaScript to be enabled.
+            </p>
+            <p class="noscript-subtext">
+                Your client either has scripts disabled or does not support it.
+                Try to <a target="_blank" rel="noopener noreferrer" href="https://www.enable-javascript.com/">enable</a>
+                scripting.
+            </p>
+        </div>
+    </noscript>
     <script type="module" src="scripts/main.js"></script>
 </body>
 


### PR DESCRIPTION
This commit adds a simply yet informative message if the client has scripting disabled. As this size makes heavy use of WebAssembly, one needs to run dynamic code. If this is not possible, the user should be informed.
This is loosely based on [this article].

[this article]: https://seapagan.medium.com/please-style-your-noscript-tags-already-765d6971e16