### PR TITLE
Add a simple loading screen

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -6,6 +6,11 @@ html {
     font-family: Arial, Helvetica, sans-serif;
 }
 
+body {
+    margin: 0;
+}
+
+/* styling of the <noscript> tag and its children */
 .noscript-msg {
     position: absolute;
     top: 0;
@@ -31,10 +36,7 @@ html {
     font-size: 1rem;
 }
 
-body {
-    margin: 0;
-}
-
+/* styling of the rendering canvas */
 canvas {
     display: block;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -7,6 +7,9 @@ html {
 }
 
 .noscript-msg {
+    position: absolute;
+    top: 0;
+    left: 0;
     display: flex;
     flex-flow: column;
     justify-content: center;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -36,6 +36,44 @@ body {
     font-size: 1rem;
 }
 
+/* the loading animation */
+#loading-animation {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    width: 100%;
+    background-color: #3B3E44;
+    color: white;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    align-items: center;
+    font-size: 20px;
+    text-transform: uppercase;
+}
+
+.loading-ring {
+    width: 2em;
+    height: 2em;
+    border: 3px solid transparent;
+    border-top-color: white;
+    border-radius: 50%;
+    animation: loading-rotation 1.25s ease infinite;
+    margin: 1.2em;
+}
+
+@keyframes loading-rotation {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
 /* styling of the rendering canvas */
 canvas {
     display: block;

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,10 @@
 </head>
 
 <body>
+    <div id="loading-animation" aria-hidden="true">
+        <div class="loading-ring"></div>
+        <span>loading...</span>
+    </div>
     <noscript>
         <div class="noscript-msg">
             <img id="noscript-img" src="images/warning.svg" alt="warning icon" />

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -15,4 +15,15 @@ window.onload = () => {
 // @ts-ignore
 import init, { } from "./wasm.js";
 
-init().then(() => console.log("initialized WASM"));
+init().then(() => {
+    console.debug("Initialization done");
+
+    // fade the loading screen out
+    const loading_screen = document.getElementById("loading-animation");
+    loading_screen?.animate([
+        { opacity: "1" },
+        { opacity: "0" },
+    ], { duration: 500, });
+    loading_screen?.style.setProperty("opacity", "0");
+    loading_screen?.addEventListener("animationiteration", () => loading_screen?.remove());
+});


### PR DESCRIPTION
This PR implements a loading spinner with the text "loading...". The spinner spins indefinitely, until the whole loading screen is removed. This happens once the WASM code is loaded. In order to prevent flashing screens when the full-screen-sized loading screen gets removed, it is faded out properly.

