### PR TITLE
Support `<canvas>` resizing on mobile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ js-sys = "0.3"
 version = "0.3"
 features = [
   "CanvasRenderingContext2d",
+  "CssStyleDeclaration",
   "Document",
   "Element",
   "HtmlCanvasElement",

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -76,5 +76,7 @@ body {
 
 /* styling of the rendering canvas */
 canvas {
+    width: 100%;
+    height: 100%;
     display: block;
 }


### PR DESCRIPTION
This PR is interesting: before it, mobile user only see a blank screen because the canvas is either not properly sized or gets resized to the wrong values.
There are two reason for this, one only involves CSS and the other needs changes in the Rust code:
- one needs to specify the widths and heights of the canvas to support the proper size (else the canvas "collapses"). This happens e.g. in mobile firefox in landscape orientation
- the code only considered a typical desktop viewport e.g. in horizontal orientation. Previously the code unconditionally used the properties `inline_size`/`block_size` as if the viewport is horizontal. Therefore the code now needs to check, which `writing-mode` is computed for the canvas element and, if it is a vertical one, swap the two dimensions.

After applying this commit, the black X on green ground also renders on mobile devices.