### PR TITLE
Display a warning if WebAssembly is unsupported

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -10,8 +10,8 @@ body {
     margin: 0;
 }
 
-/* styling of the <noscript> tag and its children */
-.noscript-msg {
+/* styling of the fullscreen-warning-messages (for no script/wasm support) */
+.fullscreen-warning-msg {
     position: absolute;
     top: 0;
     left: 0;
@@ -28,12 +28,16 @@ body {
     color: black;
 }
 
-.noscript-maintext {
+.fullscreen-warning-maintext {
     font-size: 1.5rem;
 }
 
-.noscript-subtext {
+.fullscreen-warning-subtext {
     font-size: 1rem;
+}
+
+#wasm-unsupported {
+    display: none;
 }
 
 /* the loading animation */

--- a/src/index.html
+++ b/src/index.html
@@ -18,18 +18,31 @@
         <span>loading...</span>
     </div>
     <noscript>
-        <div class="noscript-msg">
-            <img id="noscript-img" src="images/warning.svg" alt="warning icon" />
-            <p class="noscript-maintext">
-                This site is interactive and thus requires JavaScript to be enabled.
+        <div class="fullscreen-warning-msg">
+            <img src="images/warning.svg" alt="warning icon" />
+            <p class="fullscreen-warning-maintext">
+                Your Browser does not execute JavaScript.
             </p>
-            <p class="noscript-subtext">
+            <p class="fullscreen-warning-subtext">
+                This site is interactive and thus needs JavaScript enabled to be working.
                 Your client either has scripts disabled or does not support it.
                 Try to <a target="_blank" rel="noopener noreferrer" href="https://www.enable-javascript.com/">enable</a>
                 scripting.
             </p>
         </div>
     </noscript>
+    <div id="wasm-unsupported" class="fullscreen-warning-msg">
+        <img src="images/warning.svg" alt="warning icon" />
+        <p class="fullscreen-warning-maintext">
+            Your Browser does not support WebAssembly.
+        </p>
+        <p class="fullscreen-warning-subtext">
+            This site makes use of the so-called WebAssembly technology, which is a way to run code in your browser with
+            high performance.
+            Unfortunately, your client does not support it or has it disabled.
+            This may happen as a countermeasure against crypo-mining on websites.
+        </p>
+    </div>
     <script type="module" src="scripts/main.js"></script>
 </body>
 

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -26,4 +26,14 @@ init().then(() => {
     ], { duration: 500, });
     loading_screen?.style.setProperty("opacity", "0");
     loading_screen?.addEventListener("animationiteration", () => loading_screen?.remove());
+}).catch((e: any) => {
+    // the WASM file could not be initialized. This most likely is not caused by
+    // non-functioning WASM main(), but rather by a browser, that either does
+    // not support WebAssembly or has it disabled for security reasons.
+    console.error("could not initialize wasm due to " + e);
+    document.getElementById("loading-animation")?.remove();
+
+    // unhide the warning about unsupported WASM
+    const warning = document.getElementById("wasm-unsupported");
+    warning?.style?.setProperty("display", "initial");
 });


### PR DESCRIPTION
This commit generalizes the pre-existing `<noscript>`-mechanism and styling to general "fullscreen-warnings", that totally prevent the usage of the application. This generalization is done by renaming the classes in the HTML and CSS files.

The next thing is the addition of a hidden-by-default warning for the case that WASM is not supported. This is un-hidden only if the initiali- zation of the WASM threw an exception. If the initialization did work, it is simply left as-is, i.e. hidden. If a browser has WASM disabled, e.g. the chrome-based Vanadium browser by GrapheneOS I'm using, the following message is presented:
![screenshot of the new warning screen](https://github.com/jfrimmel/cirq/assets/31166235/e6809893-b071-4534-9835-d5ca175a3f2a)


The wording of the warning messages is also a little bit harmonized.