### PR TITLE
Add informational headers and footers to the site

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -15,6 +15,39 @@ body {
     flex-flow: column;
 }
 
+main {
+    /* Fill remaining space of the (`display: flex`) parent */
+    flex: 1 1 100%;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+}
+
+footer {
+    display: flex;
+    flex-direction: row;
+    align-self: center;
+    gap: 1em;
+}
+
+footer p {
+    margin: 8px;
+    align-self: center;
+}
+
+/* the general styling of UI elements like buttons or links */
+a {
+    color: cornflowerblue;
+    text-decoration: none;
+    transition-duration: 0.2s;
+    transition-timing-function: ease-in;
+}
+
+a:hover {
+    text-shadow: 0 0 0.25em rgba(255, 255, 255, 0.7);
+    color: deepskyblue;
+}
+
 /* styling of the fullscreen-warning-messages (for no script/wasm support) */
 .fullscreen-warning-msg {
     position: absolute;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -15,6 +15,19 @@ body {
     flex-flow: column;
 }
 
+header {
+    height: 1cm;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+header img {
+    height: 100%;
+    padding: 0.1cm;
+    box-sizing: border-box;
+}
+
 main {
     /* Fill remaining space of the (`display: flex`) parent */
     flex: 1 1 100%;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,13 +1,18 @@
-html {
-    height: 100%;
+html,
+body {
+    height: 100vh;
     margin: 0;
     padding: 0;
     width: 100%;
     font-family: Arial, Helvetica, sans-serif;
 }
 
-body {
-    margin: 0;
+/* the main application layout */
+.fullscreen {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-flow: column;
 }
 
 /* styling of the fullscreen-warning-messages (for no script/wasm support) */
@@ -83,4 +88,11 @@ canvas {
     width: 100%;
     height: 100%;
     display: block;
+}
+
+#renderer {
+    /* Fill remaining space of the (`display: flex`) parent */
+    flex: 1 1 100%;
+    min-width: 0;
+    min-height: 0;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -5,6 +5,8 @@ body {
     padding: 0;
     width: 100%;
     font-family: Arial, Helvetica, sans-serif;
+    background-color: #3B3E44;
+    color: white;
 }
 
 /* the main application layout */

--- a/src/index.html
+++ b/src/index.html
@@ -43,6 +43,11 @@
             This may happen as a countermeasure against crypo-mining on websites.
         </p>
     </div>
+    <div id="renderer">
+        <canvas id="rendering-surface">
+            <p>If you see this text, then the rendering of the EDA tool has broken.</p>
+        </canvas>
+    </div>
     <script type="module" src="scripts/main.js"></script>
 </body>
 

--- a/src/index.html
+++ b/src/index.html
@@ -43,10 +43,12 @@
             This may happen as a countermeasure against crypo-mining on websites.
         </p>
     </div>
-    <div id="renderer">
-        <canvas id="rendering-surface">
-            <p>If you see this text, then the rendering of the EDA tool has broken.</p>
-        </canvas>
+    <div class="fullscreen">
+        <div id="renderer">
+            <canvas id="rendering-surface">
+                <p>If you see this text, then the rendering of the EDA tool has broken.</p>
+            </canvas>
+        </div>
     </div>
     <script type="module" src="scripts/main.js"></script>
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -44,6 +44,10 @@
         </p>
     </div>
     <div class="fullscreen">
+        <header>
+            <img src="icons/icon.svg" alt="application logo" />
+            <p>Cirq</p>
+        </header>
         <main>
             <div id="renderer">
                 <canvas id="rendering-surface">

--- a/src/index.html
+++ b/src/index.html
@@ -44,11 +44,18 @@
         </p>
     </div>
     <div class="fullscreen">
-        <div id="renderer">
-            <canvas id="rendering-surface">
-                <p>If you see this text, then the rendering of the EDA tool has broken.</p>
-            </canvas>
-        </div>
+        <main>
+            <div id="renderer">
+                <canvas id="rendering-surface">
+                    <p>If you see this text, then the rendering of the EDA tool has broken.</p>
+                </canvas>
+            </div>
+        </main>
+        <footer>
+            <p>cirq — EDA solution</p>
+            <p>Source Code <a href="https://github.com/jfrimmel/cirq">GitHub</a></p>
+            <p>Version: unreleased</p>
+        </footer>
     </div>
     <script type="module" src="scripts/main.js"></script>
 </body>

--- a/src/wasm/dom.rs
+++ b/src/wasm/dom.rs
@@ -19,22 +19,15 @@ pub struct Error(()); // TODO: store the error causes for reporting
 pub fn create_canvas() -> Result<HtmlCanvasElement, Error> {
     let window = web_sys::window().ok_or(Error(()))?;
     let document = window.document().ok_or(Error(()))?;
-    let body = document.body().ok_or(Error(()))?;
 
     let canvas = document
-        .create_element("canvas")
-        .expect("<canvas> is a supported name")
+        .get_element_by_id("rendering-surface")
+        .ok_or(Error(()))?
         .dyn_into::<HtmlCanvasElement>()
-        .expect("<canvas> is convertible to `HtmlCanvasElement`");
+        .map_err(|_| Error(()))?;
 
     // put the canvas rendering surface into a container to allow styling it
-    let container = document
-        .create_element("div")
-        .expect("<div> is a supported name");
-    container.set_id("renderer");
-    container
-        .append_child(&canvas)
-        .expect("insertion should be valid");
+    let container = document.get_element_by_id("renderer").ok_or(Error(()))?;
 
     // make sure, that the canvas is resized, if the parent container has
     // changed dimensions. This way, the canvas gets resized which is internally
@@ -53,8 +46,6 @@ pub fn create_canvas() -> Result<HtmlCanvasElement, Error> {
     let observer = ResizeObserver::new(on_resize.into_js_value().unchecked_ref()).unwrap();
     observer.observe(&container);
 
-    body.append_child(&container)
-        .expect("insertion should be valid");
     Ok(canvas)
 }
 


### PR DESCRIPTION
This PR adds a header and footer, which decrease the vertical size of the canvas just as expected. As the canvas is now embedded into parent elements like `div.fullscreen` and `<main>`, the rendering elements are no more created programmatically but are present already in the HTML.
![screenshot of the result](https://github.com/jfrimmel/cirq/assets/31166235/f6bff563-6248-43f6-a407-b5db8b0f1601)
