### PR TITLE
Setup a client-side CSP and add metadata

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,13 +3,22 @@
 
 <head>
     <meta charset="utf-8" />
-    <title>cirq</title>
-    <link rel="icon" href="icons/icon.svg">
-    <link rel="stylesheet" href="css/style.css" />
-    <link rel="manifest" href="manifest.json" />
-    <meta name="description" content="Cirq — a browser-based EDA solution for schematics and PCB layout" />
+    <meta http-equiv="Content-Security-Policy" content="
+        base-uri 'self';
+        default-src 'self';
+        script-src 'self' 'wasm-unsafe-eval';
+        worker-src 'self';
+        object-src 'none';" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#DF6D07" />
+    <title>cirq</title>
+    <meta name="application-name" content="cirq">
+    <meta name="description" content="Cirq — a browser-based EDA solution for schematics and PCB layout" />
+    <link rel="icon" href="icons/icon.svg">
+    <link rel="mask-icon" href="icons/icon.svg" color="#DF6D07">
+    <link rel="stylesheet" href="css/style.css" />
+    <link rel="manifest" href="manifest.json" />
+    <meta name="mobile-web-app-capable" content="yes" />
 </head>
 
 <body>


### PR DESCRIPTION
This Pull Request primarily adds a Content Security Policy (CSP), which only allows sources from the current origin (`'self'`). Note that one needs to explicitly allow WASM and webworkers in order to support them.

The remaining commit adds a few relatively non-special metadata, which allows UAs, especially mobile browsers, to better serve the content.