### PR TITLE
Use standard `tsc` for compiling `.ts`-files

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -1,10 +1,5 @@
 builddir = build
 site = $builddir/site
-jsoutdir = $site/scripts
-
-rule tsc
-    description = Compile $in to JavaScript
-    command = tsc --strict --pretty --target es6 --module es6 --outDir $jsoutdir $in
 
 rule cp
     description = Copy $in to build directory
@@ -18,7 +13,6 @@ rule svg2ico
     description = Render $in to .ico
     command = convert -background none -define 'icon:auto-resize=16,24,32,64,128,256' $in $out
 
-build $site/scripts/main.js: tsc src/scripts/main.ts
 build $site/index.html: cp src/index.html
 build $site/manifest.json: cp src/manifest.json
 build $site/css/style.css: cp src/css/style.css
@@ -32,9 +26,16 @@ build $site/icons/128px.png: svg2png icon.svg
 build $site/icons/64px.png: svg2png icon.svg
     size = 64
 build $site/favicon.ico: svg2ico icon.svg
-build $site/worker.js: tsc src/worker.ts
-    jsoutdir = $site
 build $site/images/warning.svg: cp src/images/warning.svg
+
+rule tsc
+    description = Compile TypeScript to JavaScript
+    command = tsc --build src/scripts/main
+
+tscdir = $builddir/tsc
+build $builddir/tsc/main/main.js $builddir/tsc/service-worker/worker.js: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json
+build $site/scripts/main.js: cp $builddir/tsc/main/main.js
+build $site/worker.js: cp $builddir/tsc/service-worker/worker.js
 
 rule cargo
     description = Compile Rust to WASM

--- a/build.ninja
+++ b/build.ninja
@@ -31,6 +31,7 @@ build $site/images/warning.svg: cp src/images/warning.svg
 rule tsc
     description = Compile TypeScript to JavaScript
     command = tsc --build src/scripts/main
+    restat = true
 
 tscdir = $builddir/tsc
 build $builddir/tsc/main/main.js $builddir/tsc/service-worker/worker.js: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json

--- a/src/scripts/general-tsconfig.json
+++ b/src/scripts/general-tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "target": "ES6",
+        "rootDir": ".",
+        "outDir": "../../build/tsc",
+        "strict": true,
+        "composite": true
+    }
+}

--- a/src/scripts/main/main.ts
+++ b/src/scripts/main/main.ts
@@ -1,5 +1,3 @@
-/// <reference lib="esnext" />
-/// <reference lib="dom" />
 'use strict';
 
 window.onload = () => {

--- a/src/scripts/main/tsconfig.json
+++ b/src/scripts/main/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../general-tsconfig.json",
+    "compilerOptions": {
+        "lib": [
+            "es6",
+            "dom"
+        ],
+    },
+    "references": [
+        {
+            "path": "../service-worker"
+        }
+    ]
+}

--- a/src/scripts/service-worker/tsconfig.json
+++ b/src/scripts/service-worker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../general-tsconfig.json",
+    "compilerOptions": {
+        "lib": [
+            "esnext",
+            "webworker"
+        ],
+    }
+}

--- a/src/scripts/service-worker/worker.ts
+++ b/src/scripts/service-worker/worker.ts
@@ -10,8 +10,7 @@ self.addEventListener("install", async () => {
 });
 
 /** On a fetch, first look in cache and if missing call to network */
-self.addEventListener("fetch", (e: Event) => {
-    let event: FetchEvent = e as FetchEvent;
+self.addEventListener("fetch", event => {
     console.debug(`Trying to fetch ${event.request.url}...`);
 
     event.respondWith(fetch(event.request));

--- a/src/scripts/service-worker/worker.ts
+++ b/src/scripts/service-worker/worker.ts
@@ -1,6 +1,7 @@
-/// <reference no-default-lib="true"/>
-/// <reference lib="esnext" />
-/// <reference lib="webworker" />
+// #region typescript-workaround-for-service-worker-type
+declare var self: ServiceWorkerGlobalScope;
+export default null;
+// #endregion
 'use strict';
 
 /** On install, try to cache all necessary resources */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "references": [
+        {
+            "path": "src/scripts/main"
+        }
+    ]
+}


### PR DESCRIPTION
This PR uses the standard way of compiling TypeScript sources with the TypeScript compiler `tsc` by making use of the configuration files. Since there are issues with service-/web-workers, this again uses a somewhat special layout of typescript files such as described in this [stackoverflow] answer.
By using the `tsconfig.json` it is also possible to remove the triple- slash-annotations specifying the libraries used.

Note, that the layout in `src` does not correspond 1:1 to the layout in the `build/site` directory anymore, e.g.: the `worker.js` is in the root of the site-directory while it is inside the `scripts/service-worker`- directory inside the source-tree. But doing it this way separates the different source languages properly and doesn't clutter the root with `tsconfig`s.

The remaining commits fix some minor issues and are self-explanatory.

[stackoverflow][https://stackoverflow.com/a/56374158]