### PR TITLE
Support typing of WASM files

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -35,9 +35,13 @@ rule tsc
     command = tsc --build src/scripts/main
     restat = true
 
-build $builddir/tsc/main/main.js $builddir/tsc/service-worker/worker.js: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json
-build $site/scripts/main.js: cp $builddir/tsc/main/main.js
-build $site/worker.js: cp $builddir/tsc/service-worker/worker.js
+rule support-no-bundler
+    description = Support runnin $in in browser
+    command = sed -e "s@import \(.*\) from [\"']\(.*\)[\"']@import \1 from './\2.js'@" -e '/^export/d' $in > $out
+
+build $builddir/tsc/main/main.js $builddir/tsc/service-worker/worker.js: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json $wasmbindgendir/wasm.d.ts
+build $site/scripts/main.js: support-no-bundler $builddir/tsc/main/main.js
+build $site/worker.js: support-no-bundler $builddir/tsc/service-worker/worker.js
 
 rule cargo
     description = Compile Rust to WASM

--- a/build.ninja
+++ b/build.ninja
@@ -1,5 +1,7 @@
 builddir = build
 site = $builddir/site
+tscdir = $builddir/tsc
+wasmbindgendir = $builddir/wasm-bindgen
 
 rule cp
     description = Copy $in to build directory
@@ -33,7 +35,6 @@ rule tsc
     command = tsc --build src/scripts/main
     restat = true
 
-tscdir = $builddir/tsc
 build $builddir/tsc/main/main.js $builddir/tsc/service-worker/worker.js: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json
 build $site/scripts/main.js: cp $builddir/tsc/main/main.js
 build $site/worker.js: cp $builddir/tsc/service-worker/worker.js
@@ -46,7 +47,9 @@ rule cargo
 
 rule wasm-bindgen
     description = Generate WASM bindings
-    command = wasm-bindgen --target web --out-dir $site/scripts/ $in
+    command = wasm-bindgen --target web --out-dir $wasmbindgendir $in
 
 build $builddir/wasm32-unknown-unknown/release/wasm.wasm: cargo Cargo.toml
-build $site/scripts/wasm_bg.wasm $site/scripts/wasm_bg.wasm.d.ts $site/scripts/wasm.d.ts $site/scripts/wasm.js: wasm-bindgen $builddir/wasm32-unknown-unknown/release/wasm.wasm
+build $wasmbindgendir/wasm_bg.wasm $wasmbindgendir/wasm_bg.wasm.d.ts $wasmbindgendir/wasm.d.ts $wasmbindgendir/wasm.js: wasm-bindgen $builddir/wasm32-unknown-unknown/release/wasm.wasm
+build $site/scripts/wasm_bg.wasm: cp $wasmbindgendir/wasm_bg.wasm
+build $site/scripts/wasm.js: cp $wasmbindgendir/wasm.js

--- a/src/scripts/main/main.ts
+++ b/src/scripts/main/main.ts
@@ -10,8 +10,7 @@ window.onload = () => {
     }
 };
 
-// @ts-ignore
-import init, { } from "./wasm.js";
+import init from "wasm";
 
 init().then(() => {
     console.debug("Initialization done");

--- a/src/scripts/main/tsconfig.json
+++ b/src/scripts/main/tsconfig.json
@@ -5,6 +5,9 @@
             "es6",
             "dom"
         ],
+        "typeRoots": [
+            "../../../build/wasm-bindgen",
+        ]
     },
     "references": [
         {


### PR DESCRIPTION
_(No user-visible changes)_

Up to now, the import of the `wasm.js` file was not resolved by the TypeScript-compiler and hence any type hints, e.g. for `init`, were unavailable. This commit changes it.
    
Thankfully, `wasm-bindgen` outputs a `.d.ts`-file for the generated JS-file, so that TypeScript can reason about the types. The main change is to include the `typeRoots`-configuration for `tsc`, but there are many additional changes required:
* one needs to refer to the module by the name `"wasm"`
* as the browser does not support loading scripts this way, a new rule `support-no-bundler` was added, which replaces the import statements  `"<name>"` with `"./<name>.js"`.
* as the `.d.ts`-file is now required for the compilation of TypeScript files, the generation by `wasm-bindgen` must happen before attempting to compile these files. A dependency is added to ensure this.
* while being on it, the new `support-no-bundler`-rule also removes all  `export`-lines, as they are also not supported inside browsers.

This way, one can use the WASM-module like any other TypeScript module, e.g. with the benefits of type hints, etc..

Unfortunately, this may slow down the compilation process, as the two main compilations (Rust and TypeScript) are now in series:

![ninja -t graph](https://github.com/jfrimmel/cirq/assets/31166235/c72e3362-8142-43ed-9db9-8180a22d3a6c)

Hopefully this is not that bad, as `cargo` parallelizes internally anyways.
