### PR TITLE
Make the service worker an ES module

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -39,9 +39,9 @@ rule support-no-bundler
     description = Support runnin $in in browser
     command = sed -e "s@import \(.*\) from [\"']\(.*\)[\"']@import \1 from './\2.js'@" -e '/^export/d' $in > $out
 
-build $builddir/tsc/main/main.js: tsc src/scripts/main/main.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json $wasmbindgendir/app.d.ts
+build $builddir/tsc/main/main.js $builddir/tsc/service-worker/worker.js: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json $wasmbindgendir/app.d.ts
 build $site/scripts/main.js: support-no-bundler $builddir/tsc/main/main.js
-build $site/worker.js: cp src/scripts/service-worker/worker.js
+build $site/worker.js: support-no-bundler $builddir/tsc/service-worker/worker.js
 
 rule cargo
     description = Compile crate $crate to WASM
@@ -64,6 +64,6 @@ build $site/scripts/app.js: cp $wasmbindgendir/app.js
 build $builddir/wasm32-unknown-unknown/release/service_worker.wasm: cargo src/wasm/service_worker/Cargo.toml
     crate = service_worker
 build $wasmbindgendir/service_worker_bg.wasm $wasmbindgendir/service_worker_bg.wasm.d.ts $wasmbindgendir/service_worker.d.ts $wasmbindgendir/service_worker.js: wasm-bindgen $builddir/wasm32-unknown-unknown/release/service_worker.wasm
-    target = no-modules
+    target = web
 build $site/service_worker_bg.wasm: cp $wasmbindgendir/service_worker_bg.wasm
 build $site/service_worker.js: cp $wasmbindgendir/service_worker.js

--- a/src/scripts/main/main.ts
+++ b/src/scripts/main/main.ts
@@ -6,7 +6,7 @@ window.onload = () => {
     // e.g. it simply does not support PWAs or it runs in private mode or the
     // connection to the site is untrusted/unencrypted.
     if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('worker.js');
+        navigator.serviceWorker.register('worker.js', { type: 'module' });
     }
 };
 

--- a/src/scripts/service-worker/tsconfig.json
+++ b/src/scripts/service-worker/tsconfig.json
@@ -2,16 +2,11 @@
     "extends": "../general-tsconfig.json",
     "compilerOptions": {
         "lib": [
-            "es6",
-            "dom"
+            "esnext",
+            "webworker"
         ],
         "typeRoots": [
             "../../../build/wasm-bindgen",
-        ]
-    },
-    "references": [
-        {
-            "path": "../service-worker"
-        }
-    ]
+        ],
+    }
 }

--- a/src/scripts/service-worker/worker.ts
+++ b/src/scripts/service-worker/worker.ts
@@ -2,7 +2,13 @@
 //!
 //! This script is merely a call to the WASM, that is the actual service worker.
 //! Any actual work is done over on the Rust side.
-importScripts("./service_worker.js");
+'use strict';
+import * as wasm from "service_worker";
+
+// #region typescript-workaround-for-service-worker-type
+declare var self: ServiceWorkerGlobalScope;
+export default null;
+// #endregion
 
 /// Initialize the WASM in the service worker.
 ///
@@ -11,8 +17,7 @@ importScripts("./service_worker.js");
 /// different context.
 async function initialize() {
     console.debug("[service worker] trying to load WASM...");
-    await wasm_bindgen("./service_worker_bg.wasm");
-
-    wasm_bindgen.initialize();
+    await wasm.default();
+    wasm.initialize();
 }
 initialize();


### PR DESCRIPTION
I've just learned, that `navigator.serviceWorker.register()` takes an optional [argument, that may specify, that the service worker should be a module][mdn] (`type: "module"`). This is much cleaner than the classic way and integrates way better into the (just newly removed) TypeScript environment, as now things like `import` are possible again. Therefore this commit does some re-adjustments including the revert of the commit, that moved from TypeScript to JavaScript for the service worker (`336a70d`), as now there is again a reason to use TypeScript.

[mdn]: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register