### PR TITLE
Improve the build system

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -32,7 +32,7 @@ build $site/images/warning.svg: cp src/images/warning.svg
 
 rule tsc
     description = Compile TypeScript to JavaScript
-    command = tsc --build src/scripts/main
+    command = tsc --build --force src/scripts/main
     restat = true
 
 rule support-no-bundler

--- a/build.ninja
+++ b/build.ninja
@@ -36,7 +36,7 @@ rule tsc
     restat = true
 
 rule support-no-bundler
-    description = Support runnin $in in browser
+    description = Support running $in in browser
     command = sed -e "s@import \(.*\) from [\"']\(.*\)[\"']@import \1 from './\2.js'@" -e '/^export/d' $in > $out
 
 build build $builddir/tsc/main/main.js $builddir/tsc/main/tsconfig.tsbuildinfo $builddir/tsc/service-worker/worker.js $builddir/tsc/service-worker/tsconfig.tsbuildinfo: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json $wasmbindgendir/app.d.ts $wasmbindgendir/service_worker.d.ts

--- a/build.ninja
+++ b/build.ninja
@@ -39,7 +39,7 @@ rule support-no-bundler
     description = Support runnin $in in browser
     command = sed -e "s@import \(.*\) from [\"']\(.*\)[\"']@import \1 from './\2.js'@" -e '/^export/d' $in > $out
 
-build $builddir/tsc/main/main.js $builddir/tsc/service-worker/worker.js: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json $wasmbindgendir/app.d.ts
+build build $builddir/tsc/main/main.js $builddir/tsc/main/tsconfig.tsbuildinfo $builddir/tsc/service-worker/worker.js $builddir/tsc/service-worker/tsconfig.tsbuildinfo: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json $wasmbindgendir/app.d.ts
 build $site/scripts/main.js: support-no-bundler $builddir/tsc/main/main.js
 build $site/worker.js: support-no-bundler $builddir/tsc/service-worker/worker.js
 

--- a/build.ninja
+++ b/build.ninja
@@ -39,7 +39,7 @@ rule support-no-bundler
     description = Support runnin $in in browser
     command = sed -e "s@import \(.*\) from [\"']\(.*\)[\"']@import \1 from './\2.js'@" -e '/^export/d' $in > $out
 
-build build $builddir/tsc/main/main.js $builddir/tsc/main/tsconfig.tsbuildinfo $builddir/tsc/service-worker/worker.js $builddir/tsc/service-worker/tsconfig.tsbuildinfo: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json $wasmbindgendir/app.d.ts
+build build $builddir/tsc/main/main.js $builddir/tsc/main/tsconfig.tsbuildinfo $builddir/tsc/service-worker/worker.js $builddir/tsc/service-worker/tsconfig.tsbuildinfo: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json $wasmbindgendir/app.d.ts $wasmbindgendir/service_worker.d.ts
 build $site/scripts/main.js: support-no-bundler $builddir/tsc/main/main.js
 build $site/worker.js: support-no-bundler $builddir/tsc/service-worker/worker.js
 


### PR DESCRIPTION
* properly support `ninja -t clean` even with typescript artifacts
* prevent build race-conditions like [this](https://app.circleci.com/pipelines/github/jfrimmel/cirq/72/workflows/af75fb63-5070-4806-9474-d55db6a55286/jobs/90)
* Force whole rebuilds of the TypeScript-project

    This is somewhat unfortunate, but necessary for the following reason. The TypeScript-compiler `tcs` has an internal incremental compilation, that does not take the type-definitions (`.d.ts`) into account, i.e. even if the `ninja` triggered a re-compilation, `tsc` will not actually recompile anything.
    This is especially bad if someone changes the signature of a public function, which causes `wasm-bindgen` to generate changed type definitions and finally `tsc` to _ignore_ the changes altogether... This will **not** detect the errors in the TypeScript-files!

    Fortunately, this is only relevant locally, but thankfully not in CI, as that always does clean builds.