### PR TITLE
Fix loading screen animation on slow networks

### DIFF
--- a/src/scripts/main/main.ts
+++ b/src/scripts/main/main.ts
@@ -17,12 +17,12 @@ init().then(() => {
 
     // fade the loading screen out
     const loading_screen = document.getElementById("loading-animation");
-    loading_screen?.animate([
+    const animation = loading_screen?.animate([
         { opacity: "1" },
         { opacity: "0" },
     ], { duration: 500, });
-    loading_screen?.style.setProperty("opacity", "0");
-    loading_screen?.addEventListener("animationiteration", () => loading_screen?.remove());
+    animation?.addEventListener("finish", () => loading_screen?.remove());
+    animation?.play();
 }).catch((e: any) => {
     // the WASM file could not be initialized. This most likely is not caused by
     // non-functioning WASM main(), but rather by a browser, that either does


### PR DESCRIPTION
The loading screen animation previously was not properly started. This was not a problem, if the network was fast enough (but I don't know why) and only broke on slower networks, e.g. "Regular 2G" in the Firefox Networking-tab.
This commit fixes it by actually playing the animation and removing it directly afterwards, now, that the "finish" event works (which it did not previously, as the animation was not properly started).