### PR TITLE
Add a custom title bar to desktop PWAs

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -18,14 +18,19 @@ body {
 }
 
 header {
-    height: 1cm;
     display: flex;
     flex-direction: row;
     align-items: center;
+    /* for the PWA overlay on desktops */
+    left: env(titlebar-area-x, 0);
+    top: env(titlebar-area-y, 0);
+    width: env(titlebar-area-width, 100%);
+    height: max(env(titlebar-area-height), 1cm);
+    -webkit-app-region: drag;
 }
 
 header img {
-    height: 100%;
+    height: 0.8cm;
     padding: 0.1cm;
     box-sizing: border-box;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -29,6 +29,32 @@ header {
     -webkit-app-region: drag;
 }
 
+header input[type="search"] {
+    background-color: #3B3E44;
+    color: white;
+    padding: 4px;
+    border: 1px solid white;
+    border-radius: 0.125cm;
+
+    flex-grow: 1;
+    max-width: 10cm;
+    margin: 0 auto;
+    /* no not drag the window if the user wants to click inside the search bar*/
+    -webkit-app-region: no-drag;
+}
+
+header input[type="search"]:focus {
+    background-color: white;
+    color: #3B3E44;
+    outline: none;
+    border-color: #3B3E44;
+}
+
+header input[type="search"]::placeholder {
+    color: lightgray;
+    text-align: center;
+}
+
 header img {
     height: 0.8cm;
     padding: 0.1cm;

--- a/src/index.html
+++ b/src/index.html
@@ -56,6 +56,7 @@
         <header>
             <img src="icons/icon.svg" alt="application logo" />
             <p>Cirq</p>
+            <input type="search" id="searchbar" placeholder="Search or type a command" />
         </header>
         <main>
             <div id="renderer">

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,11 @@
     "name": "cirq",
     "start_url": ".",
     "display": "standalone",
+    "display_override": [
+        "window-controls-overlay"
+    ],
     "background_color": "#3B3E44",
-    "theme_color": "#22be22",
+    "theme_color": "#3B3E44",
     "icons": [
         {
             "src": "icons/icon.svg",


### PR DESCRIPTION
This commit adds the following title bar to the PWAs (ignore the orange buttons on the right):
![screenshot of new title bar under Linux/KDE and Chromium](https://github.com/jfrimmel/cirq/assets/31166235/746ce931-f4e6-41f4-a1c0-a571d7c9c4ed)
The whole gray area, except for the search bar, is drag-able and serves as the title bar of the application.