### PR TITLE
Improve the visual representation of the titlebar and searchbar

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -37,8 +37,8 @@ header input[type="search"] {
     border-radius: 0.125cm;
 
     flex-grow: 1;
-    max-width: 10cm;
-    margin: 0 auto;
+    margin-left: 1cm;
+    margin-right: 0.5cm;
     /* no not drag the window if the user wants to click inside the search bar*/
     -webkit-app-region: no-drag;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -32,7 +32,7 @@ header {
 header input[type="search"] {
     background-color: #3B3E44;
     color: white;
-    padding: 4px;
+    padding: 8px;
     border: 1px solid white;
     border-radius: 0.125cm;
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -43,6 +43,18 @@ header input[type="search"] {
     -webkit-app-region: no-drag;
 }
 
+@media only screen and (min-width: 1000px) {
+    header input[type="search"] {
+        position: fixed;
+        left: 50%;
+        transform: translate(-50%);
+
+        margin: 0 auto;
+        width: 600px;
+        flex-grow: unset;
+    }
+}
+
 header input[type="search"]:focus {
     background-color: white;
     color: #3B3E44;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -25,7 +25,7 @@ header {
     left: env(titlebar-area-x, 0);
     top: env(titlebar-area-y, 0);
     width: env(titlebar-area-width, 100%);
-    height: max(env(titlebar-area-height), 1cm);
+    height: max(env(titlebar-area-height), 4em);
     -webkit-app-region: drag;
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -10,12 +10,12 @@
         worker-src 'self';
         object-src 'none';" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#DF6D07" />
+    <meta name="theme-color" content="#3B3E44" />
     <title>cirq</title>
     <meta name="application-name" content="cirq">
     <meta name="description" content="Cirq — a browser-based EDA solution for schematics and PCB layout" />
     <link rel="icon" href="icons/icon.svg">
-    <link rel="mask-icon" href="icons/icon.svg" color="#DF6D07">
+    <link rel="mask-icon" href="icons/icon.svg" color="#3B3E44">
     <link rel="stylesheet" href="css/style.css" />
     <link rel="manifest" href="manifest.json" />
     <meta name="mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
This PR applies both to PWA and the web. It changes how the search bar is displayed, firstly by giving it more padding to make it bigger and to make the search text (placeholder) look not that dense. To do this, the title bar is now a little bit higher.
The search bar is now more responsive to screen width changes:
* on small screens, the search bar fills the remaining space:
    ![screenshot of small window with expanded search bar](https://github.com/jfrimmel/cirq/assets/31166235/72dd0675-0a37-45d7-957b-824ea40356c4)
* on larger screens, the search bar has a good-looking maximum width and is in the center:
    ![screenshot of larger window with centered search bar](https://github.com/jfrimmel/cirq/assets/31166235/9218390a-6d0c-426b-ba04-8c532d6a9a25)

Another very important thing is, that the orange title bar/PWA overlay is gone! It now blends in with the custom title bar.