### PR TITLE
Fix the `support-no-bundler`-rule

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -37,11 +37,12 @@ rule tsc
 
 rule support-no-bundler
     description = Support running $in in browser
-    command = sed -e "s@import \(.*\) from [\"']\(.*\)[\"']@import \1 from './\2.js'@" -e '/^export/d' $in > $out
+    command = sed -e "s@import \(.*\) from [\"']\(.*\)[\"']@import \1 from './\2.js'@" $parameter $in > $out
 
 build build $builddir/tsc/main/main.js $builddir/tsc/main/tsconfig.tsbuildinfo $builddir/tsc/service-worker/worker.js $builddir/tsc/service-worker/tsconfig.tsbuildinfo: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json $wasmbindgendir/app.d.ts
 build $site/scripts/main.js: support-no-bundler $builddir/tsc/main/main.js
 build $site/worker.js: support-no-bundler $builddir/tsc/service-worker/worker.js
+    parameter = -e '/^export default/d'
 
 rule cargo
     description = Compile crate $crate to WASM


### PR DESCRIPTION
This rule previously did delete all lines, that contain a line starting with `export`. This was wrong for multiple reasons: only the service worker must not have the additional `export default null;`-line, that is only necessary for TypeScript anyways. Another important point is, that the main application code might need to use another module at some point and this module will need to export classes/functions/etc. which would be broken by this rule.

Therefore the build script is adopted to to only filter out that line for the service worker and to don't interfere with normal application modules.