### PR TITLE
Add versioning and support pure-offline PWA

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -3,6 +3,12 @@ site = $builddir/site
 tscdir = $builddir/tsc
 wasmbindgendir = $builddir/wasm-bindgen
 
+rule generate-version
+    description = Generate version info file
+    command = git rev-list --count HEAD > $out
+
+build $site/.version: generate-version .git/index
+
 rule cp
     description = Copy $in to build directory
     command = cp $in $out

--- a/build.ninja
+++ b/build.ninja
@@ -43,12 +43,19 @@ rule tsc
 
 rule support-no-bundler
     description = Support running $in in browser
-    command = sed -e "s@import \(.*\) from [\"']\(.*\)[\"']@import \1 from './\2.js'@" $parameter $in > $out
+    command = sed -e "s@import \(.*\) from [\"']\(.*\)[\"']@import \1 from './\2.js'@" $in > $out
 
 build build $builddir/tsc/main/main.js $builddir/tsc/main/tsconfig.tsbuildinfo $builddir/tsc/service-worker/worker.js $builddir/tsc/service-worker/tsconfig.tsbuildinfo: tsc src/scripts/main/main.ts src/scripts/service-worker/worker.ts | src/scripts/general-tsconfig.json src/scripts/main/tsconfig.json src/scripts/service-worker/tsconfig.json $wasmbindgendir/app.d.ts
 build $site/scripts/main.js: support-no-bundler $builddir/tsc/main/main.js
-build $site/worker.js: support-no-bundler $builddir/tsc/service-worker/worker.js
-    parameter = -e '/^export default/d'
+
+rule process-worker
+    # Workers cannot be modules and need a different version on every commit. We
+    # use the content of the `.version`-file generated beforehand (an implicit
+    # rule is required to enforce this).
+    description = Pre-processing service worker source
+    command = sed -e '/^export default/d' -e "s/\$$version/$$(cat $site/.version)/" $in > $out
+
+build $site/worker.js: process-worker $builddir/tsc/service-worker/worker.js | $site/.version
 
 rule cargo
     description = Compile crate $crate to WASM

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -174,6 +174,34 @@ a:hover {
     }
 }
 
+/* styling of the update notification */
+#update-available {
+    display: none;
+    position: fixed;
+    left: 50%;
+    margin: 8px;
+    max-width: min(8cm, 60%);
+    transform: translate(-50%);
+    background-color: crimson;
+    border: 3px white;
+    border-radius: 8px;
+    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.7);
+}
+
+#update-available button {
+    background-color: transparent;
+    border: none;
+    color: white;
+    padding: 8px;
+    border-radius: 8px;
+    transition: 0.5s;
+}
+
+#update-available button:hover {
+    background-color: rgba(255, 255, 255, 0.3);
+}
+
+
 /* styling of the rendering canvas */
 canvas {
     width: 100%;

--- a/src/index.html
+++ b/src/index.html
@@ -59,6 +59,10 @@
             <input type="search" id="searchbar" placeholder="Search or type a command" />
         </header>
         <main>
+            <div id="update-available">
+                <button id="update-accept">Click here for applying the latest update...</button>
+                <button id="update-close">&times;</button>
+            </div>
             <div id="renderer">
                 <canvas id="rendering-surface">
                     <p>If you see this text, then the rendering of the EDA tool has broken.</p>

--- a/src/scripts/main/main.ts
+++ b/src/scripts/main/main.ts
@@ -30,14 +30,17 @@ window.onload = async () => {
             registry?.waiting?.postMessage("perform-update");
         }
 
-        function offer_update() {
-            const btn = document.createElement("button");
-            btn.textContent = "update!"
-            btn.style.position = "absolute";
-            btn.style.left = "50px";
-            btn.style.top = "50px";
-            btn.onclick = apply_update;
-            document.body.append(btn);
+        /** Show a minimal notification to either apply or dismiss the update */
+        async function offer_update() {
+            const message = document.getElementById("update-available");
+            const accept_button = document.getElementById("update-accept");
+            const close_button = document.getElementById("update-close");
+
+            message?.style.setProperty("display", "unset");
+            accept_button?.addEventListener("click", apply_update);
+            close_button?.addEventListener("click", () => {
+                message?.style.setProperty("display", "none");
+            });
         }
 
         // refer to https://stackoverflow.com/a/37582216 for this construct

--- a/src/scripts/service-worker/worker.ts
+++ b/src/scripts/service-worker/worker.ts
@@ -12,18 +12,13 @@
 //! and won't communicate to any server.
 //!
 //! # Updates
-//! The only exception to this is the searching for updates once in a while. If
-//! the worker should search for an update (e.g. because the update interval has
-//! ended), the worker will contact the PWA-server and check, if there is a new
-//! version of the application (if the device is currently offline, this is fine
-//! and just nothing happens). If there is a newer version available, the
-//! resources are downloaded automatically and stored in a newer cache version,
-//! while keeping the current version active. Only if the page is reloaded by
-//! the user, the newer versions of the resources are used.
-//!
-//! The user should actively decide to update the page, e.g. by clicking on a
-//! button, that only is visible if there is an update (this needs to be
-//! communicated by the service worker to the actual PWA).
+//! The update procedure is very simple: the service worker source file changes
+//! on any release (thanks to the monotonically increasing version number, that
+//! is inserted at build time), which causes the browser to install a new ver-
+//! sion of the service worker. On installation, this new service worker will
+//! fetch all the resources of the current PWA version. This way a new version
+//! is automatically installed on every new version on the server. The user can
+//! then be notified to reload the site to switch to the new worker.
 //!
 //! # Script vs WASM
 //! In a perfect world, this would just forward to a WASM as well, but this is
@@ -45,6 +40,10 @@
 //!
 //! [at the moment]: https://caniuse.com/mdn-api_serviceworker_ecmascript_modules
 'use strict';
+
+/** The version of this PWA build. */
+// `$version` is replaced at build time with the actual version
+const VERSION = "v$version";
 
 // #region typescript-workaround-for-service-worker-type
 declare var self: ServiceWorkerGlobalScope;

--- a/src/scripts/service-worker/worker.ts
+++ b/src/scripts/service-worker/worker.ts
@@ -45,6 +45,39 @@
 // `$version` is replaced at build time with the actual version
 const VERSION = "v$version";
 
+/**
+ * The list of files to cache.
+ *
+ * This list must include all static files except for the server version. Note,
+ * that this list must also include all names to all files, e.g. often `/` is
+ * an alternative name for `/index.html`, so both must be in the list. This list
+ * can be generated automatically using the following pipeline:
+ * ```bash
+ * find build/site/ -type f |
+ *     sort |
+ *     grep -v 'build/site/worker.js' |
+ *     sed -e 's@build/site/\(.*\)@"\1",@' -e '1i"/",'`
+ * ```
+ * Do not include the service worker file itself, as this prevents PWA updates.
+ */
+const SITE_RESOURCES = [
+    "/",
+    "css/style.css",
+    "favicon.ico",
+    "icons/128px.png",
+    "icons/256px.png",
+    "icons/512px.png",
+    "icons/64px.png",
+    "icons/icon.svg",
+    "images/warning.svg",
+    "index.html",
+    "manifest.json",
+    "scripts/app_bg.wasm",
+    "scripts/app.js",
+    "scripts/main.js",
+    ".version",
+];
+
 // #region typescript-workaround-for-service-worker-type
 declare var self: ServiceWorkerGlobalScope;
 export default null;


### PR DESCRIPTION
This commit makes the application usable as a pure offline application. This is done by implementing a typical service worker, which caches all of its assets on installation. The new worker will not be active immediately, but will prompt the user to decide, whether he wants to apply this update now or later:
![an update is available](https://github.com/jfrimmel/cirq/assets/31166235/fa1d669e-3819-41ab-b060-067316281003)
The optics are not great, but the implementation behind it is working: if there is a new release on the server (only checked on a site load/reload), the new version is downloaded in the background. The old service worker keeps being active and handles all requests until the user accepts the update (or closes the app and the browser applies it implicitly). The client and worker are communicating the update process and after it is finished, the client script reloads the page to view the new version.

Possible extensions include
* searching for updates in the background and when the app is running
* showing system-wide notifications using the `Notification`-API.
