### PR TITLE
Display the running PWA version in the footer

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -5,7 +5,7 @@ wasmbindgendir = $builddir/wasm-bindgen
 
 rule generate-version
     description = Generate version info file
-    command = git rev-list --count HEAD > $out
+    command = git rev-list --count --merges HEAD > $out
 
 build $site/.version: generate-version .git/index
 

--- a/src/index.html
+++ b/src/index.html
@@ -73,7 +73,7 @@
             <p>cirq — EDA solution</p>
             <p>Source Code <a href="https://github.com/jfrimmel/cirq" target="_blank"
                     rel="noopener noreferrer">GitHub</a></p>
-            <p>Version: unreleased</p>
+            <p>Version: <span id="version">unknown</span></p>
         </footer>
     </div>
     <script type="module" src="scripts/main.js"></script>

--- a/src/scripts/main/main.ts
+++ b/src/scripts/main/main.ts
@@ -57,6 +57,11 @@ window.onload = async () => {
         }
 
     }
+
+    const version = await fetch(".version");
+    const text = await version.text();
+    const node = document.getElementById("version");
+    if (node) node.textContent = "alpha-" + text;
 };
 
 import init from "app";


### PR DESCRIPTION
This commit displays the number of merges of the released&deployed branch (always `main`) in the version-info-field in the footer. This is much better than just writing "unreleased". Currently it writes `alpha-<nr>` to indicate the alpha-stadium of the software.