### PR TITLE
Adopt to GitHub pages start point

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -1,5 +1,5 @@
 builddir = build
-site = $builddir/site
+site = $builddir/site/cirq
 tscdir = $builddir/tsc
 wasmbindgendir = $builddir/wasm-bindgen
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,7 @@
 {
     "name": "cirq",
-    "start_url": ".",
+    "id": "/cirq/",
+    "start_url": "/cirq/",
     "display": "standalone",
     "display_override": [
         "window-controls-overlay"


### PR DESCRIPTION
GitHub pages has the application root at the `/cirq`-entry point instead of `/`, as the page is available at `https://jfrimmel.github.io/cirq/` and not just `https://jfrimmel.github.io/`. Therefore the PWA manifest should reflect this. Else the service worker cannot cache the right re- sources (currently the PWA service worker installation on the live app fails for this reason).

In order to not change the local development to much, the site assets are also moved to a `/cirq`-directory within the old HTTP-server loca- tion. So, one still needs to run `python -m http.server` in `build/site` and just navigate to `localhost:8000/cirq`.