### PR TITLE
Try to fix the site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
           name: Disable jekyll builds
           command: touch build/site/.nojekyll
       - run:
+          name: Move PWA start to sub-directory
+          command: sed -i 's|"/"|"/cirq"|' build/site/manifest.json
+      - run:
           # https://discuss.circleci.com/t/cant-ignore-the-gh-pages-branch/2002/4
           name: Add CircleCI definitions for this branch
           command: mkdir build/site/.circleci && cp .circleci/config.yml build/site/.circleci/config.yml

--- a/build.ninja
+++ b/build.ninja
@@ -1,5 +1,5 @@
 builddir = build
-site = $builddir/site/cirq
+site = $builddir/site
 tscdir = $builddir/tsc
 wasmbindgendir = $builddir/wasm-bindgen
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,6 @@
 {
     "name": "cirq",
-    "id": "/cirq/",
-    "start_url": "/cirq/",
+    "start_url": ".",
     "display": "standalone",
     "display_override": [
         "window-controls-overlay"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,7 @@
 {
     "name": "cirq",
-    "start_url": ".",
+    "id": "/",
+    "start_url": "/",
     "display": "standalone",
     "display_override": [
         "window-controls-overlay"


### PR DESCRIPTION
#34 broke the live site, so this reverts this. Instead, the PWA entry point is only modified on a deploy to GitHub Pages.