### PR TITLE
Make the whole titlebar draggable

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -18,18 +18,25 @@ body {
 }
 
 header {
+    /* make sure, that the whole header is draggable */
+    min-height: max(env(titlebar-area-height, 4em), 4em);
+    -webkit-app-region: drag;
+}
+
+.titlebar {
     display: flex;
     flex-direction: row;
     align-items: center;
     /* for the PWA overlay on desktops */
+    position: absolute;
     left: env(titlebar-area-x, 0);
     top: env(titlebar-area-y, 0);
     width: env(titlebar-area-width, 100%);
-    height: max(env(titlebar-area-height), 4em);
+    height: max(env(titlebar-area-height, 4em), 4em);
     -webkit-app-region: drag;
 }
 
-header input[type="search"] {
+.titlebar input[type="search"] {
     background-color: #3B3E44;
     color: white;
     padding: 8px;
@@ -44,7 +51,7 @@ header input[type="search"] {
 }
 
 @media only screen and (min-width: 1000px) {
-    header input[type="search"] {
+    .titlebar input[type="search"] {
         position: fixed;
         left: 50%;
         transform: translate(-50%);
@@ -55,19 +62,19 @@ header input[type="search"] {
     }
 }
 
-header input[type="search"]:focus {
+.titlebar input[type="search"]:focus {
     background-color: white;
     color: #3B3E44;
     outline: none;
     border-color: #3B3E44;
 }
 
-header input[type="search"]::placeholder {
+.titlebar input[type="search"]::placeholder {
     color: lightgray;
     text-align: center;
 }
 
-header img {
+.titlebar img {
     height: 0.8cm;
     padding: 0.1cm;
     box-sizing: border-box;

--- a/src/index.html
+++ b/src/index.html
@@ -54,9 +54,11 @@
     </div>
     <div class="fullscreen">
         <header>
-            <img src="icons/icon.svg" alt="application logo" />
-            <p>Cirq</p>
-            <input type="search" id="searchbar" placeholder="Search or type a command" />
+            <div class="titlebar">
+                <img src="icons/icon.svg" alt="application logo" />
+                <p>Cirq</p>
+                <input type="search" id="searchbar" placeholder="Search or type a command" />
+            </div>
         </header>
         <main>
             <div id="update-available">


### PR DESCRIPTION
The titlebar is artificially enlarged on desktop PWAs in order to fit the search bar into the titlebar. The problem was, that only the header- element was marked as draggable, but that element does not span 100% of the window width, but is only in between of the overlay elements (the system buttons). This prevented dragging the window at the space below those UI elements.
Therefore this commit adds a new div `.titlebar`, which only is as large as the usable space, but the previous `<header>`-element takes now 100% of the width. The whole header is draggable, so the problem is fixed.

Furthermore the new titlebar-container is now positioned absolute, which is required on platforms, that have the system UI on the left side.