### PR TITLE
Change version to `0.x` instead of `alpha-x`

### DIFF
--- a/src/scripts/main/main.ts
+++ b/src/scripts/main/main.ts
@@ -61,7 +61,7 @@ window.onload = async () => {
     const version = await fetch(".version");
     const text = await version.text();
     const node = document.getElementById("version");
-    if (node) node.textContent = "alpha-" + text;
+    if (node) node.textContent = "0." + text;
 };
 
 import init from "app";


### PR DESCRIPTION
Nowadays users are used to seeing version numbers like `x.y.z`, but the current version `alpha-36` doen't really look like a version to an ordinary user.

Thefore this commit changes the visual reprentation of the version num- ber to a more familiar format.